### PR TITLE
Add and test Python 3 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ sudo: false
 python:
   - pypy-5.4.1
   - 2.7
+  - 3.5
 script:
-  - python setup.py test
+  - coverage run setup.py test
 after_success:
   - coveralls
 notifications:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@
 
 - Add continuous integration testing for supported Python versions.
 - Add PyPy support.
+- Add Python 3 support.
 - Drop support for Python less than 2.7.
 - Remove ZODB3 dependency in favor of explicit dependencies on BTrees.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setuptools.setup(
         "Framework :: Zope3",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],

--- a/src/zc/intid/utility.py
+++ b/src/zc/intid/utility.py
@@ -31,7 +31,7 @@ import zope.security.proxy
 
 unwrap = zope.security.proxy.removeSecurityProxy
 
-
+@zope.interface.implementer(zc.intid.IIntIds, zc.intid.IIntIdsSubclass)
 class IntIds(persistent.Persistent):
     """This utility provides a two way mapping between objects and
     integer ids.
@@ -39,10 +39,6 @@ class IntIds(persistent.Persistent):
     The objects are stored directly in the internal structures.
 
     """
-
-    zope.interface.implements(
-        zc.intid.IIntIds,
-        zc.intid.IIntIdsSubclass)
 
     _v_nextid = None
 
@@ -134,10 +130,10 @@ class Event(object):
         self.idmanager = idmanager
         self.id = id
 
-
+@zope.interface.implementer(zc.intid.IIdAddedEvent)
 class AddedEvent(Event):
-    zope.interface.implements(zc.intid.IIdAddedEvent)
+    pass
 
-
+@zope.interface.implementer(zc.intid.IIdRemovedEvent)
 class RemovedEvent(Event):
-    zope.interface.implements(zc.intid.IIdRemovedEvent)
+    pass

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy
+envlist = py27,pypy,py35
 
 [testenv]
 deps =


### PR DESCRIPTION
Very minor changes, happily. The only code change required was fixing the interface declarations. The tests have a few changes to remove deprecation warnings, but those were all mechanical. Locally I verified coverage remains at 100%.

Fixes #2.