### PR TITLE
Fix zope-intid.zcml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 install:
   - pip install -U pip setuptools
   - pip install -U coverage coveralls
-  - pip install -U -e .
+  - pip install -U -e .[test]
 # cache: pip seems not to work if `install` is replaced (https://github.com/travis-ci/travis-ci/issues/3239)
 cache:
   directories:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@
 - Add Python 3 support.
 - Drop support for Python less than 2.7.
 - Remove ZODB3 dependency in favor of explicit dependencies on BTrees.
+- The zope-intid.zcml file included in this package now works to make
+  the IntId utility from this package implement the zope.intids
+  interface, if that package is installed.
 
 1.0.1 (2011-06-27)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,10 @@ def read(*rnames):
 
 version = "2.0.0.dev0"
 
+tests_require = [
+    'zope.configuration',
+]
+
 setuptools.setup(
     name="zc.intid",
     version=version,
@@ -59,6 +63,10 @@ setuptools.setup(
         "zope.interface",
         "zope.security",
     ],
+    tests_require=tests_require,
+    extras_require={
+        'test': tests_require,
+    },
     include_package_data=True,
     zip_safe=False,
     test_suite="zc.intid.tests",

--- a/src/zc/intid/zope-intid.zcml
+++ b/src/zc/intid/zope-intid.zcml
@@ -3,21 +3,18 @@
     xmlns:zcml="http://namespaces.zope.org/zcml"
     >
 
-  <!-- Make your zc.intid utilities also provide the parallel
-       zope.intid interfaces.
-       -->
+  <!--
+      Make your zc.intid utilities also provide the parallel
+      zope.intid interfaces.
+  -->
+
+  <!-- For the <class> directive -->
+  <include package="zope.security" file="meta.zcml" />
 
   <!-- For "modern" int id utilities (zope.intid): -->
   <configure zcml:condition="installed zope.intid">
     <class class=".utility.IntIds">
-      <interface interface="zope.intid.interfaces.IIntIds"/>
-    </class>
-  </configure>
-
-  <!-- For "classic" int id utilities (zope.app.intid): -->
-  <configure zcml:condition="not:installed zope.intid">
-    <class class=".utility.IntIds">
-      <interface interface="zope.app.intid.interfaces.IIntIds"/>
+      <implements interface="zope.intid.interfaces.IIntIds"/>
     </class>
   </configure>
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py27,pypy,py35
 
 [testenv]
 deps =
+     .[test]
     coverage
 commands =
     coverage run setup.py test


### PR DESCRIPTION
Add test cases. Remove the legacy zope.app.intid support because it never worked anyway.

Fixes #5