### PR TITLE
Raise specific error subclasses.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@
 - Propagate ``POSKeyError`` from ``queryId`` instead of returning the
   default object. This exception indicates a corrupt database, not a
   missing object. The ``queryObject`` function already behaved this way.
+- Attempting to ``register`` an object that cannot have the utility's
+  attribute set on it (for example, it has restrictive ``__slots__``)
+  no longer corrupts the utility's state.
 
 1.0.1 (2011-06-27)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,14 @@
 - Interfaces and event implementations have been refactored into the
   new module :mod:`zc.intid.interfaces`. Backwards compatibility
   aliases remain for the old names. See :issue:`9`.
+- Raise more informative KeyError subclasses from the utility when intids
+  or objects cannot be found. This distinguishes them from errors
+  raised by normal dictionaries or BTrees, and is useful in unit
+  testing or when persisting intids or sharing them among processes
+  for later or concurrent use. See :issue:`8`
+- Propagate ``POSKeyError`` from ``queryId`` instead of returning the
+  default object. This exception indicates a corrupt database, not a
+  missing object. The ``queryObject`` function already behaved this way.
 
 1.0.1 (2011-06-27)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setuptools.setup(
         "zope.security",
         # Subscribers
         "zope.lifecycleevent",
-        "zope.intid",
+        "zope.intid >= 4.2",
         "zope.keyreference",
     ],
     tests_require=tests_require,

--- a/src/zc/intid/interfaces.py
+++ b/src/zc/intid/interfaces.py
@@ -27,6 +27,19 @@ The :class:`IIntIdsSubclass` and event interfaces are new.
 
 import zope.interface
 
+import zope.intid.interfaces
+
+class IntIdMismatchError(zope.intid.interfaces.IntIdMissingError):
+    """
+    Raised from ``getId`` if the id of an object doesn't match
+    what's recorded in the utility.
+    """
+
+class IntIdInUseError(ValueError):
+    """
+    Raised by the utility when ``register`` tries to reuse
+    an intid.
+    """
 
 class IIntIdsQuery(zope.interface.Interface):
     """
@@ -34,10 +47,20 @@ class IIntIdsQuery(zope.interface.Interface):
     """
 
     def getObject(uid):
-        """Return an object by its unique id"""
+        """
+        Return an object by its unique id
+
+        Raises :exc:`zope.intid.interfaces.ObjectMissingError` if
+        there is no object with that id.
+        """
 
     def getId(ob):
-        """Get a unique id of an object.
+        """
+        Get a unique id of an object.
+
+        Raises :exc:`zope.intid.interfaces.IntIdMissingError` if
+        there is no id for that object. Raises :exc:`IntIdMismatchError`
+        if the recorded id doesn't match the id of the object.
         """
 
     def queryObject(uid, default=None):
@@ -131,6 +154,9 @@ class IIntIdsSubclass(zope.interface.Interface):
         reference to the objects they're generated for.
 
         This method may be overriden.
+
+        If this method returns an id that is already in use,
+        ``register`` will raise an :exc:`IntIdInUseError`.
 
         """
 

--- a/src/zc/intid/interfaces.py
+++ b/src/zc/intid/interfaces.py
@@ -50,17 +50,18 @@ class IIntIdsQuery(zope.interface.Interface):
         """
         Return an object by its unique id
 
-        Raises :exc:`zope.intid.interfaces.ObjectMissingError` if
-        there is no object with that id.
+        :raises zope.intid.interfaces.ObjectMissingError: if
+          there is no object with that id.
         """
 
     def getId(ob):
         """
         Get a unique id of an object.
 
-        Raises :exc:`zope.intid.interfaces.IntIdMissingError` if
-        there is no id for that object. Raises :exc:`IntIdMismatchError`
-        if the recorded id doesn't match the id of the object.
+        :raises zope.intid.interfaces.IntIdMissingError: if
+           there is no id for that object.
+        :raises zc.intid.interfaces.IntIdMismatchError: if the recorded id
+           doesn't match the id of the object.
         """
 
     def queryObject(uid, default=None):
@@ -96,9 +97,10 @@ class IIntIdsSet(zope.interface.Interface):
         """
 
     def unregister(ob):
-        """Remove the object from the indexes.
+        """
+        Remove the object from the indexes.
 
-        KeyError is raised if ob is not registered previously.
+        If the *ob* is not previously registered, this has no effect.
 
         An :class:`IIdRemovedEvent` is triggered for successful
         unregistrations.

--- a/src/zc/intid/tests/test_subscribers.py
+++ b/src/zc/intid/tests/test_subscribers.py
@@ -50,10 +50,7 @@ from zope.interface import Interface
 from zope.intid.interfaces import IIntIdEvent
 from zope.intid.interfaces import IntIdAddedEvent
 from zope.intid.interfaces import IntIdRemovedEvent
-try:
-    from zope.intid.interfaces import ObjectMissingError
-except ImportError:
-    ObjectMissingError = KeyError
+from zope.intid.interfaces import ObjectMissingError
 
 from zope.keyreference.interfaces import IKeyReference
 

--- a/src/zc/intid/tests/test_utility.py
+++ b/src/zc/intid/tests/test_utility.py
@@ -25,6 +25,9 @@ from zc.intid.interfaces import IIdAddedEvent
 from zc.intid.interfaces import IIdRemovedEvent
 from zc.intid.interfaces import IIntIds
 from zc.intid.interfaces import IIntIdsSubclass
+from zc.intid.interfaces import IntIdMismatchError
+from zc.intid.interfaces import IntIdInUseError
+
 
 from zc.intid.utility import IntIds
 
@@ -33,6 +36,9 @@ from zope.interface.verify import verifyObject
 
 from zope.security.checker import CheckerPublic
 from zope.security.proxy import Proxy
+
+from zope.intid.interfaces import IntIdMissingError
+from zope.intid.interfaces import ObjectMissingError
 
 import zope.event
 
@@ -71,12 +77,12 @@ class TestIntIds(unittest.TestCase):
         # `getId` raises a KeyError with the proxied object if it isn't
         # in its mapping.
         obj.iid = None
-        with self.assertRaises(KeyError) as ex:
+        with self.assertRaises(IntIdMissingError) as ex:
             u.getId(proxied)
         self.assertIs(ex.exception.args[0], proxied)
 
         obj.iid = -1
-        with self.assertRaises(KeyError) as ex:
+        with self.assertRaises(IntIdMismatchError) as ex:
             u.getId(proxied)
         self.assertIs(ex.exception.args[0], proxied)
 
@@ -85,14 +91,14 @@ class TestIntIds(unittest.TestCase):
         obj.iid = iid
         proxied = Proxy(obj,
                         CheckerPublic)
-        with self.assertRaises(KeyError) as ex:
+        with self.assertRaises(IntIdMissingError) as ex:
             u.getId(proxied)
         self.assertIs(ex.exception.args[0], proxied)
 
     def test_non_keyreferences(self):
         #
         # This test, copied from zope.intid, was used in that context to
-        # determine that failed adaptaions to IKeyReference did not
+        # determine that failed adaptations to IKeyReference did not
         # cause unexpected behaviors from the API.
         #
         # In zc.intid, this simple ensures that the behaviors don't
@@ -103,14 +109,14 @@ class TestIntIds(unittest.TestCase):
 
         self.assertIsNone(u.queryId(obj))
         self.assertIsNone(u.unregister(obj))
-        self.assertRaises(KeyError, u.getId, obj)
+        self.assertRaises(IntIdMissingError, u.getId, obj)
 
     def test(self):
         u = self.createIntIds()
         obj = P()
 
-        self.assertRaises(KeyError, u.getId, obj)
-        self.assertRaises(KeyError, u.getId, P())
+        self.assertRaises(IntIdMissingError, u.getId, obj)
+        self.assertRaises(IntIdMissingError, u.getId, P())
 
         self.assertIsNone(u.queryId(obj))
         self.assertIs(u.queryId(obj, 42), 42)
@@ -138,8 +144,8 @@ class TestIntIds(unittest.TestCase):
 
         u.unregister(obj)
         self.assertIsNone(obj.iid)
-        self.assertRaises(KeyError, u.getObject, uid)
-        self.assertRaises(KeyError, u.getId, obj)
+        self.assertRaises(ObjectMissingError, u.getObject, uid)
+        self.assertRaises(IntIdMissingError, u.getId, obj)
 
         # Check the id-removed event:
         self.assertEqual(len(self.events), 3)
@@ -267,13 +273,41 @@ class TestIntIds(unittest.TestCase):
         self.assertEqual(obj.iid, 42)
 
         # Check that the exception is raised:
-        self.assertRaises(ValueError, u.register, P())
+        self.assertRaises(IntIdInUseError, u.register, P())
 
         # Verify that the original registration isn't compromised:
         self.assertIs(u.getObject(42), obj)
         self.assertIs(u.queryObject(42), obj)
         self.assertEqual(u.getId(obj), uid)
         self.assertEqual(u.queryId(obj), uid)
+
+    def test_poskeyerror_propagates_getObject(self):
+        from ZODB.POSException import POSKeyError
+
+        class BadDict(object):
+            def __getitem__(self, k):
+                raise POSKeyError()
+
+        u = self.createIntIds()
+        u.refs = BadDict()
+
+        self.assertRaises(POSKeyError, u.getObject, 1)
+
+    def test_poskeyerror_propagates_queryId(self):
+        from ZODB.POSException import POSKeyError
+
+        class BadDict(object):
+            def __getitem__(self, k):
+                raise POSKeyError()
+
+        u = self.createIntIds()
+        obj = P()
+        u.register(obj)
+        u.refs = BadDict()
+
+        self.assertRaises(POSKeyError, u.getId, obj)
+        self.assertRaises(POSKeyError, u.queryId, obj)
+
 
 
 class TestIntIds64(TestIntIds):

--- a/src/zc/intid/tests/test_utility.py
+++ b/src/zc/intid/tests/test_utility.py
@@ -308,6 +308,28 @@ class TestIntIds(unittest.TestCase):
         self.assertRaises(POSKeyError, u.getId, obj)
         self.assertRaises(POSKeyError, u.queryId, obj)
 
+    def test_unsettable_attr_doesnt_corrupt(self):
+        # An error on setting the attribute doesn't leak a reference to
+        # the object
+        from ZODB.POSException import POSKeyError
+        u = self.createIntIds()
+
+        class WithSlots(object):
+            __slots__ = ()
+
+        obj = WithSlots()
+
+        self.assertRaises(AttributeError, u.register, obj)
+        self.assertEqual(0, len(u))
+
+        class Broken(object):
+            def __setattr__(self, name, value):
+
+                raise POSKeyError()
+
+        obj = Broken()
+        self.assertRaises(POSKeyError, u.register, obj)
+        self.assertEqual(0, len(u))
 
 
 class TestIntIds64(TestIntIds):

--- a/src/zc/intid/utility.py
+++ b/src/zc/intid/utility.py
@@ -137,7 +137,12 @@ class IntIds(persistent.Persistent):
             if uid in self.refs:
                 raise IntIdInUseError("id generator returned used id")
         self.refs[uid] = ob
-        setattr(ob, self.attribute, uid)
+        try:
+            setattr(ob, self.attribute, uid)
+        except:
+            # cleanup our mess
+            del self.refs[uid]
+            raise
         notify(AddedEvent(ob, self, uid))
         return uid
 
@@ -146,6 +151,7 @@ class IntIds(persistent.Persistent):
         uid = self.queryId(ob)
         if uid is None:
             return
+        # This should not raise KeyError, we checked that in queryId
         del self.refs[uid]
         setattr(ob, self.attribute, None)
         notify(RemovedEvent(ob, self, uid))

--- a/src/zc/intid/utility.py
+++ b/src/zc/intid/utility.py
@@ -23,11 +23,28 @@ This functionality can be used in cataloging.
 from zc.intid.interfaces import AddedEvent
 from zc.intid.interfaces import IIntIds
 from zc.intid.interfaces import IIntIdsSubclass
+from zc.intid.interfaces import IntIdMismatchError
+from zc.intid.interfaces import IntIdInUseError
 from zc.intid.interfaces import RemovedEvent
 
 from zope.event import notify
 
 from zope.interface import implementer
+
+from zope.intid.interfaces import IntIdMissingError
+from zope.intid.interfaces import ObjectMissingError
+try:
+    # POSKeyError is a subclass of KeyError; in the cases where we
+    # catch KeyError for an item missing from a BTree, we still
+    # want to propagate this exception that indicates a corrupt database
+    # (as opposed to a corrupt IntIds)
+    from ZODB.POSException import POSKeyError as _POSKeyError
+except ImportError: # pragma: no cover (we run tests with ZODB installed)
+    # In practice, ZODB will probably be installed. But if not,
+    # then POSKeyError can never be generated, so use a unique
+    # exception that we'll never catch.
+    class _POSKeyError(BaseException):
+        pass
 
 from zope.security.proxy import removeSecurityProxy as unwrap
 
@@ -66,7 +83,12 @@ class IntIds(persistent.Persistent):
         return self.refs.iterkeys()
 
     def getObject(self, id):
-        return self.refs[id]
+        try:
+            return self.refs[id]
+        except _POSKeyError:
+            raise
+        except KeyError:
+            raise ObjectMissingError(id)
 
     def queryObject(self, id, default=None):
         if id in self.refs:
@@ -77,15 +99,17 @@ class IntIds(persistent.Persistent):
         unwrapped = unwrap(ob)
         uid = getattr(unwrapped, self.attribute, None)
         if uid is None:
-            raise KeyError(ob)
+            raise IntIdMissingError(ob)
         if uid not in self.refs or self.refs[uid] is not unwrapped:
             # not an id that matches
-            raise KeyError(ob)
+            raise IntIdMismatchError(ob)
         return uid
 
     def queryId(self, ob, default=None):
         try:
             return self.getId(ob)
+        except _POSKeyError:
+            raise
         except KeyError:
             return default
 
@@ -111,7 +135,7 @@ class IntIds(persistent.Persistent):
         if uid is None:
             uid = self.generateId(ob)
             if uid in self.refs:
-                raise ValueError("id generator returned used id")
+                raise IntIdInUseError("id generator returned used id")
         self.refs[uid] = ob
         setattr(ob, self.attribute, uid)
         notify(AddedEvent(ob, self, uid))


### PR DESCRIPTION
Fixes #8

Also make sure that POSKeyError propagates from queryId